### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,7 @@
 1. Add `nuxt-vercel-analytics` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-vercel-analytics
-
-# Using yarn
-yarn add --dev nuxt-vercel-analytics
-
-# Using npm
-npm install --save-dev nuxt-vercel-analytics
+npx nuxi@latest module add vercel-analytics
 ```
 
 2. Add `nuxt-vercel-analytics` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -16,18 +16,8 @@
 
 ## 🔧 Setup
 
-1. Add `nuxt-vercel-analytics` dependency to your project
-
 ```bash
 npx nuxi@latest module add vercel-analytics
-```
-
-2. Add `nuxt-vercel-analytics` to the `modules` section of `nuxt.config.ts`
-
-```js
-export default defineNuxtConfig({
-  modules: ["nuxt-vercel-analytics"],
-});
 ```
 
 That's it! Vercel Analytics is now integrated in your Nuxt app ✨


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
